### PR TITLE
Convert cuda_histogram-feedstock to v1 feedstock

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,11 +31,21 @@ pkgs_dirs:
 solver: libmamba
 
 CONDARC
-mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-%H-%M-%S)
-echo > /opt/conda/conda-meta/history
-micromamba install --root-prefix ~/.conda --prefix /opt/conda \
-    --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+curl -fsSL https://pixi.sh/install.sh | bash
+export PATH="~/.pixi/bin:$PATH"
+pushd "${FEEDSTOCK_ROOT}"
+arch=$(uname -m)
+if [[ "$arch" == "x86_64" ]]; then
+  arch="64"
+fi
+sed -i.bak "s/platforms = .*/platforms = [\"linux-${arch}\"]/" pixi.toml
+echo "Creating environment"
+PIXI_CACHE_DIR=/opt/conda pixi install
+pixi list
+echo "Activating environment"
+eval "$(pixi shell-hook)"
+mv pixi.toml.bak pixi.toml
+popd
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc
@@ -49,7 +59,7 @@ source run_conda_forge_build_setup
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${HOST_PLATFORM}" != linux-* ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
-    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --test skip"
 fi
 
 
@@ -60,20 +70,16 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
 fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
-        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
-    fi
-    conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-
-    # Drop into an interactive shell
-    /bin/bash
+    echo "rattler-build currently doesn't support debug mode"
 else
-    conda-build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
-        --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
+
+    rattler-build build --recipe "${RECIPE_ROOT}" \
+     -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+     ${EXTRA_CB_OPTIONS:-} \
+     --target-platform "${HOST_PLATFORM}" \
+     --extra-meta flow_run_id="${flow_run_id:-}" \
+     --extra-meta remote_url="${remote_url:-}" \
+     --extra-meta sha="${sha:-}"
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 
     # inspect_artifacts was only added in conda-forge-ci-setup 4.9.4

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -11,3 +11,5 @@ provider:
   linux_aarch64: default
   linux_ppc64le: default
 test: native_and_emulated
+conda_install_tool: pixi
+conda_build_tool: rattler-build

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,60 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: toml -*-
+
+[project]
+name = "cuda_histogram-feedstock"
+version = "3.47.0"
+description = "Pixi configuration for conda-forge/cuda_histogram-feedstock"
+authors = ["@conda-forge/cuda_histogram"]
+channels = ["conda-forge"]
+platforms = ["linux-64", "linux-aarch64", "linux-ppc64le", "osx-64", "win-64"]
+
+[dependencies]
+conda-build = ">=24.1"
+conda-forge-ci-setup = "4.*"
+rattler-build = "*"
+
+[tasks]
+inspect-all = "inspect_artifacts --all-packages"
+build = "rattler-build build --recipe recipe"
+"build-linux_64_python3.10.____cpython" = "rattler-build build --recipe recipe -m .ci_support/linux_64_python3.10.____cpython.yaml"
+"inspect-linux_64_python3.10.____cpython" = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_python3.10.____cpython.yaml"
+"build-linux_64_python3.11.____cpython" = "rattler-build build --recipe recipe -m .ci_support/linux_64_python3.11.____cpython.yaml"
+"inspect-linux_64_python3.11.____cpython" = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_python3.11.____cpython.yaml"
+"build-linux_64_python3.12.____cpython" = "rattler-build build --recipe recipe -m .ci_support/linux_64_python3.12.____cpython.yaml"
+"inspect-linux_64_python3.12.____cpython" = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_python3.12.____cpython.yaml"
+"build-linux_64_python3.13.____cp313" = "rattler-build build --recipe recipe -m .ci_support/linux_64_python3.13.____cp313.yaml"
+"inspect-linux_64_python3.13.____cp313" = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_python3.13.____cp313.yaml"
+"build-linux_64_python3.9.____cpython" = "rattler-build build --recipe recipe -m .ci_support/linux_64_python3.9.____cpython.yaml"
+"inspect-linux_64_python3.9.____cpython" = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_python3.9.____cpython.yaml"
+"build-linux_aarch64_python3.10.____cpython" = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_python3.10.____cpython.yaml"
+"inspect-linux_aarch64_python3.10.____cpython" = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_python3.10.____cpython.yaml"
+"build-linux_aarch64_python3.11.____cpython" = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_python3.11.____cpython.yaml"
+"inspect-linux_aarch64_python3.11.____cpython" = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_python3.11.____cpython.yaml"
+"build-linux_aarch64_python3.12.____cpython" = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_python3.12.____cpython.yaml"
+"inspect-linux_aarch64_python3.12.____cpython" = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_python3.12.____cpython.yaml"
+"build-linux_aarch64_python3.13.____cp313" = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_python3.13.____cp313.yaml"
+"inspect-linux_aarch64_python3.13.____cp313" = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_python3.13.____cp313.yaml"
+"build-linux_aarch64_python3.9.____cpython" = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_python3.9.____cpython.yaml"
+"inspect-linux_aarch64_python3.9.____cpython" = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_python3.9.____cpython.yaml"
+"build-linux_ppc64le_python3.10.____cpython" = "rattler-build build --recipe recipe -m .ci_support/linux_ppc64le_python3.10.____cpython.yaml"
+"inspect-linux_ppc64le_python3.10.____cpython" = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_ppc64le_python3.10.____cpython.yaml"
+"build-linux_ppc64le_python3.11.____cpython" = "rattler-build build --recipe recipe -m .ci_support/linux_ppc64le_python3.11.____cpython.yaml"
+"inspect-linux_ppc64le_python3.11.____cpython" = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_ppc64le_python3.11.____cpython.yaml"
+"build-linux_ppc64le_python3.12.____cpython" = "rattler-build build --recipe recipe -m .ci_support/linux_ppc64le_python3.12.____cpython.yaml"
+"inspect-linux_ppc64le_python3.12.____cpython" = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_ppc64le_python3.12.____cpython.yaml"
+"build-linux_ppc64le_python3.9.____cpython" = "rattler-build build --recipe recipe -m .ci_support/linux_ppc64le_python3.9.____cpython.yaml"
+"inspect-linux_ppc64le_python3.9.____cpython" = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_ppc64le_python3.9.____cpython.yaml"
+
+[feature.smithy.dependencies]
+conda-smithy = "*"
+
+[feature.smithy.tasks]
+build-locally = "python ./build-locally.py"
+smithy = "conda-smithy"
+rerender = "conda-smithy rerender"
+lint = "conda-smithy lint recipe"
+
+[environments]
+smithy = ["smithy"]

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,23 +1,26 @@
-{% set name = "cuda_histogram" %}
-{% set version = "0.1.1" %}
+schema_version: 1
+
+context:
+  name: cuda_histogram
+  version: 0.1.1
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: ${{ name|lower }}
+  version: ${{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
   sha256: 3089502c63f7fc1e26a81ca7f5a307ad14c01101f35b91b92dc2a56ef4a4bf38
   patches:
     # Patch `pyproject.toml`'s requirement on `cupy-cuda12x` to `cupy` to fix `pip check`
     - cupy.patch
 
 build:
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
   # linux-ppc64le is not supported by CuPy on Python 3.13
   # https://github.com/conda-forge/cupy-feedstock/issues/299
-  skip: true  # [win or osx or (ppc64le and py>312)]
+  number: 1
+  skip: win or osx or (ppc64le and match(python, ">3.12"))
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
@@ -34,21 +37,19 @@ requirements:
     - hist >=2
     - boost-histogram
 
-test:
-  imports:
-    - cuda_histogram
-    - cuda_histogram.axis
-  requires:
-    - pip
-  commands:
-    - pip check
+tests:
+  - python:
+      imports:
+        - cuda_histogram
+        - cuda_histogram.axis
+      pip_check: true
 
 about:
-  home: https://github.com/scikit-hep/cuda-histogram
-  summary: 'Histogramming tools on CUDA'
+  summary: Histogramming tools on CUDA
   license: BSD-3-Clause
   license_file: LICENSE
-  doc_url: https://cuda-histogram.readthedocs.io/
+  homepage: https://github.com/scikit-hep/cuda-histogram
+  documentation: https://cuda-histogram.readthedocs.io/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
This PR converts cuda_histogram-feedstock to a v1 recipe and switch the conda build tool to rattler-build.
It has been automatically generated with [feedrattler v0.3.12](https://github.com/hadim/feedrattler).

Changes:
- [x] 📝 Converted `meta.yaml` to `recipe.yaml`
- [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
- [x] 🔧 Updated `conda-forge.yml` to use `rattler-build` and `pixi` (optional)
- [x] 🔢 Bumped the build number
- [x] 🐍 Applied temporary fixes for `python_min` and `python_version`
- [x] 🔄 Rerender the feedstock with conda-smithy
- [x] Ensured the license file is being packaged.
